### PR TITLE
feat: add support for Gemini CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Global home affects all projects. Project folder only affects the current direct
 ## What it does
 
 - Keeps `.agents` as the source of truth.
-- Creates symlinks for Claude, Codex, Factory, Cursor, and OpenCode (based on your selection).
+- Creates symlinks for Claude, Codex, Factory, Cursor, OpenCode, and Gemini (based on your selection).
 - Always creates a backup before any overwrite so changes are reversible.
 
 ## Where it links (global scope)
@@ -39,6 +39,10 @@ Global home affects all projects. Project folder only affects the current direct
 
 `.agents/AGENTS.md` → `~/.claude/CLAUDE.md` (fallback when no CLAUDE.md)
 
+`.agents/GEMINI.md` → `~/.gemini/GEMINI.md` (if present)
+
+`.agents/AGENTS.md` → `~/.gemini/GEMINI.md` (fallback when no GEMINI.md)
+
 `.agents/commands` → `~/.claude/commands`
 
 `.agents/commands` → `~/.factory/commands`
@@ -46,6 +50,10 @@ Global home affects all projects. Project folder only affects the current direct
 `.agents/commands` → `~/.codex/prompts`
 
 `.agents/commands` → `~/.cursor/commands`
+
+`.agents/commands` → `~/.config/opencode/commands`
+
+`.agents/commands` → `~/.gemini/commands`
 
 `.agents/hooks` → `~/.claude/hooks`
 
@@ -57,8 +65,6 @@ Global home affects all projects. Project folder only affects the current direct
 
 `.agents/AGENTS.md` → `~/.config/opencode/AGENTS.md`
 
-`.agents/commands` → `~/.config/opencode/commands`
-
 `.agents/skills` → `~/.claude/skills`
 
 `.agents/skills` → `~/.factory/skills`
@@ -69,7 +75,9 @@ Global home affects all projects. Project folder only affects the current direct
 
 `.agents/skills` → `~/.config/opencode/skills`
 
-Project scope links only commands/hooks/skills into the project’s client folders (no AGENTS/CLAUDE rules).
+`.agents/skills` → `~/.gemini/skills`
+
+Project scope links only commands/hooks/skills into the project’s client folders (no AGENTS/CLAUDE/GEMINI rules).
 
 ## Development
 
@@ -100,7 +108,8 @@ bun run build
 - Codex prompts always symlink to `.agents/commands` (canonical source).
 - Skills require a valid `SKILL.md` with `name` + `description` frontmatter.
 - Claude prompt precedence: if `.agents/CLAUDE.md` exists, it links to `.claude/CLAUDE.md`. Otherwise `.agents/AGENTS.md` is used. After adding or removing `.agents/CLAUDE.md`, re-run dotagents and apply/repair links to update the symlink. Factory/Codex always link to `.agents/AGENTS.md`.
-- Project scope creates `.agents` plus client folders for commands/hooks/skills only. Rule files (`AGENTS.md`/`CLAUDE.md`) are left to the repo root so you can manage them explicitly.
+- Gemini context file precedence: if `.agents/GEMINI.md` exists, it links to `.gemini/GEMINI.md`. Otherwise `.agents/AGENTS.md` is used. After adding or removing `.agents/GEMINI.md`, re-run dotagents and apply/repair links to update the symlink.
+- Project scope creates `.agents` plus client folders for commands/hooks/skills only. Rule files (`AGENTS.md`/`CLAUDE.md`/`GEMINI.md`) are left to the repo root so you can manage them explicitly.
 - Backups are stored under `.agents/backup/<timestamp>` and can be restored via “Undo last change.”
 
 ## License

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -29,19 +29,21 @@ function exitCancelled() {
 
 function mergeAgentStatus(items: LinkStatus[]): LinkStatus[] {
   const claudeEntry = items.find((s) => s.name === 'claude-md') || null;
+  const geminiEntry = items.find((s) => s.name === 'gemini-md') || null;
   const agentsEntry = items.find((s) => s.name === 'agents-md') || null;
-  if (!claudeEntry && !agentsEntry) return items;
+  if (!claudeEntry && !agentsEntry && !geminiEntry) return items;
 
   const merged: LinkStatus = {
     name: 'agents-md',
-    source: claudeEntry?.source || agentsEntry?.source || '',
+    source: claudeEntry?.source || geminiEntry?.source || agentsEntry?.source || '',
     targets: [
       ...(claudeEntry?.targets || []),
+      ...(geminiEntry?.targets || []),
       ...(agentsEntry?.targets || []),
     ],
   };
 
-  const withoutAgents = items.filter((s) => s.name !== 'claude-md' && s.name !== 'agents-md');
+  const withoutAgents = items.filter((s) => s.name !== 'claude-md' && s.name !== 'gemini-md' && s.name !== 'agents-md');
   return [merged, ...withoutAgents];
 }
 
@@ -49,6 +51,7 @@ function displayName(entry: LinkStatus): string {
   if (entry.name === 'agents-md') {
     const sourceFile = path.basename(entry.source);
     if (sourceFile === 'CLAUDE.md') return 'AGENTS.md (Claude override)';
+    if (sourceFile === 'GEMINI.md') return 'AGENTS.md (Gemini override)';
     return 'AGENTS.md';
   }
   return entry.name;
@@ -132,6 +135,7 @@ async function selectClients(): Promise<Client[]> {
     { label: 'Codex', value: 'codex' },
     { label: 'Cursor', value: 'cursor' },
     { label: 'OpenCode', value: 'opencode' },
+    { label: 'Gemini', value: 'gemini' },
   ] as const;
   const selected = await multiselect({
     message: 'Select clients to manage',
@@ -150,6 +154,7 @@ function formatClients(clients: Client[]): string {
     codex: 'Codex',
     cursor: 'Cursor',
     opencode: 'OpenCode',
+    gemini: 'Gemini',
   };
   return clients.map((c) => names[c]).join(', ');
 }

--- a/src/core/mappings.ts
+++ b/src/core/mappings.ts
@@ -14,9 +14,11 @@ export async function getMappings(opts: MappingOptions): Promise<Mapping[]> {
   const roots = resolveRoots(opts);
   const canonical = roots.canonicalRoot;
   const claudeOverride = path.join(canonical, 'CLAUDE.md');
+  const geminiOverride = path.join(canonical, 'GEMINI.md');
   const agentsFallback = path.join(canonical, 'AGENTS.md');
-  const agentsSource = await pathExists(claudeOverride) ? claudeOverride : agentsFallback;
-  const clients = new Set<Client>(opts.clients ?? ['claude', 'factory', 'codex', 'cursor', 'opencode']);
+  const claudeSource = await pathExists(claudeOverride) ? claudeOverride : agentsFallback;
+  const geminiSource = await pathExists(geminiOverride) ? geminiOverride : agentsFallback;
+  const clients = new Set<Client>(opts.clients ?? ['claude', 'factory', 'codex', 'cursor', 'opencode', 'gemini']);
   const opencodeSkillsRoot = opts.scope === 'global' ? roots.opencodeConfigRoot : roots.opencodeRoot;
 
   const mappings: Mapping[] = [];
@@ -24,8 +26,17 @@ export async function getMappings(opts: MappingOptions): Promise<Mapping[]> {
   if (includeAgentFiles && clients.has('claude')) {
     mappings.push({
       name: 'claude-md',
-      source: agentsSource,
+      source: claudeSource,
       targets: [path.join(roots.claudeRoot, 'CLAUDE.md')],
+      kind: 'file',
+    });
+  }
+
+  if (includeAgentFiles && clients.has('gemini')) {
+    mappings.push({
+      name: 'gemini-md',
+      source: geminiSource,
+      targets: [path.join(roots.geminiRoot, 'GEMINI.md')],
       kind: 'file',
     });
   }
@@ -57,6 +68,7 @@ export async function getMappings(opts: MappingOptions): Promise<Mapping[]> {
         clients.has('codex') ? path.join(roots.codexRoot, 'prompts') : null,
         clients.has('opencode') ? path.join(roots.opencodeRoot, 'commands') : null,
         clients.has('cursor') ? path.join(roots.cursorRoot, 'commands') : null,
+        clients.has('gemini') ? path.join(roots.geminiRoot, 'commands') : null,
       ].filter(Boolean) as string[],
       kind: 'dir',
     },
@@ -78,6 +90,7 @@ export async function getMappings(opts: MappingOptions): Promise<Mapping[]> {
         clients.has('codex') ? path.join(roots.codexRoot, 'skills') : null,
         clients.has('opencode') ? path.join(opencodeSkillsRoot, 'skills') : null,
         clients.has('cursor') ? path.join(roots.cursorRoot, 'skills') : null,
+        clients.has('gemini') ? path.join(roots.geminiRoot, 'skills') : null,
       ].filter(Boolean) as string[],
       kind: 'dir',
     },

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -60,7 +60,7 @@ export async function scanMigration(opts: RootOptions & { clients?: Client[] }):
   const roots = resolveRoots(opts);
   const canonicalRoot = roots.canonicalRoot;
   const candidatesByTarget = new Map<string, MigrationCandidate[]>();
-  const clients = new Set<Client>(opts.clients ?? ['claude', 'factory', 'codex', 'cursor', 'opencode']);
+  const clients = new Set<Client>(opts.clients ?? ['claude', 'factory', 'codex', 'cursor', 'opencode', 'gemini']);
   const includeAgentFiles = opts.scope === 'global';
 
   const canonicalCommands = path.join(canonicalRoot, 'commands');
@@ -77,6 +77,7 @@ export async function scanMigration(opts: RootOptions & { clients?: Client[] }):
       clients.has('codex') ? { label: 'Codex prompts', dir: path.join(roots.codexRoot, 'prompts') } : null,
       clients.has('cursor') ? { label: 'Cursor commands', dir: path.join(roots.cursorRoot, 'commands') } : null,
       clients.has('opencode') ? { label: 'OpenCode commands', dir: path.join(roots.opencodeRoot, 'commands') } : null,
+      clients.has('gemini') ? { label: 'Gemini commands', dir: path.join(roots.geminiRoot, 'commands') } : null,
     ].filter(Boolean) as { label: string; dir: string }[],
     hooks: [
       clients.has('claude') ? { label: 'Claude hooks', dir: path.join(roots.claudeRoot, 'hooks') } : null,
@@ -88,6 +89,7 @@ export async function scanMigration(opts: RootOptions & { clients?: Client[] }):
       clients.has('codex') ? { label: 'Codex skills', dir: path.join(roots.codexRoot, 'skills') } : null,
       clients.has('cursor') ? { label: 'Cursor skills', dir: path.join(roots.cursorRoot, 'skills') } : null,
       clients.has('opencode') ? { label: 'OpenCode skills', dir: path.join(opencodeSkillsRoot, 'skills') } : null,
+      clients.has('gemini') ? { label: 'Gemini skills', dir: path.join(roots.geminiRoot, 'skills') } : null,
     ].filter(Boolean) as { label: string; dir: string }[],
     agents: includeAgentFiles
       ? [
@@ -100,6 +102,11 @@ export async function scanMigration(opts: RootOptions & { clients?: Client[] }):
     claude: includeAgentFiles
       ? [
           clients.has('claude') ? { label: 'Claude CLAUDE.md', file: path.join(roots.claudeRoot, 'CLAUDE.md') } : null,
+        ].filter(Boolean) as { label: string; file: string }[]
+      : [],
+    gemini: includeAgentFiles
+      ? [
+          clients.has('gemini') ? { label: 'Gemini GEMINI.md', file: path.join(roots.geminiRoot, 'GEMINI.md') } : null,
         ].filter(Boolean) as { label: string; file: string }[]
       : [],
   } as const;
@@ -150,6 +157,12 @@ export async function scanMigration(opts: RootOptions & { clients?: Client[] }):
   for (const src of sources.claude) {
     if (!await pathExists(src.file) || await isSymlink(src.file)) continue;
     addCandidate({ label: src.label, targetPath: canonicalClaude, kind: 'file', action: 'copy', sourcePath: src.file });
+  }
+
+  const canonicalGemini = path.join(canonicalRoot, 'GEMINI.md');
+  for (const src of sources.gemini) {
+    if (!await pathExists(src.file) || await isSymlink(src.file)) continue;
+    addCandidate({ label: src.label, targetPath: canonicalGemini, kind: 'file', action: 'copy', sourcePath: src.file });
   }
 
   const auto: MigrationCandidate[] = [];

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -16,6 +16,7 @@ export type ResolvedRoots = {
   cursorRoot: string;
   opencodeRoot: string;
   opencodeConfigRoot: string;
+  geminiRoot: string;
   projectRoot: string;
   homeDir: string;
 };
@@ -32,6 +33,7 @@ export function resolveRoots(opts: RootOptions): ResolvedRoots {
       cursorRoot: path.join(homeDir, '.cursor'),
       opencodeRoot: path.join(homeDir, '.config', 'opencode'),
       opencodeConfigRoot: path.join(homeDir, '.config', 'opencode'),
+      geminiRoot: path.join(homeDir, '.gemini'),
       projectRoot,
       homeDir,
     };
@@ -44,6 +46,7 @@ export function resolveRoots(opts: RootOptions): ResolvedRoots {
     cursorRoot: path.join(projectRoot, '.cursor'),
     opencodeRoot: path.join(projectRoot, '.opencode'),
     opencodeConfigRoot: path.join(homeDir, '.config', 'opencode'),
+    geminiRoot: path.join(projectRoot, '.gemini'),
     projectRoot,
     homeDir,
   };

--- a/src/core/plan.ts
+++ b/src/core/plan.ts
@@ -63,12 +63,19 @@ export async function buildLinkPlan(opts: MappingOptions): Promise<LinkPlan> {
 
   for (const mapping of mappings) {
     tasks.push(...await ensureSourceTask(mapping.source, mapping.kind));
-    const relinkableSources = mapping.name === 'claude-md'
-      ? [
+    let relinkableSources: string[] | undefined;
+    if (mapping.name === 'claude-md') {
+      relinkableSources = [
         path.join(path.dirname(mapping.source), 'AGENTS.md'),
         path.join(path.dirname(mapping.source), 'CLAUDE.md'),
-      ]
-      : undefined;
+      ];
+    } else if (mapping.name === 'gemini-md') {
+      relinkableSources = [
+        path.join(path.dirname(mapping.source), 'AGENTS.md'),
+        path.join(path.dirname(mapping.source), 'GEMINI.md'),
+      ];
+    }
+
     for (const target of mapping.targets) {
       tasks.push(await analyzeTarget(mapping.source, target, mapping.kind, { relinkableSources }));
     }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,6 +1,6 @@
 export type Scope = 'global' | 'project';
 export type SourceKind = 'file' | 'dir';
-export type Client = 'claude' | 'factory' | 'codex' | 'cursor' | 'opencode';
+export type Client = 'claude' | 'factory' | 'codex' | 'cursor' | 'opencode' | 'gemini';
 
 export type Mapping = {
   name: string;

--- a/tests/linking.test.ts
+++ b/tests/linking.test.ts
@@ -37,18 +37,22 @@ test('creates symlinks from canonical .agents to tool homes', async () => {
   const opencodeAgents = path.join(home, '.config', 'opencode', 'AGENTS.md');
   const cursorSkills = path.join(home, '.cursor', 'skills');
   const opencodeSkills = path.join(home, '.config', 'opencode', 'skills');
+  const geminiCommands = path.join(home, '.gemini', 'commands');
+  const geminiSkills = path.join(home, '.gemini', 'skills');
 
   expect(await readLinkTarget(claudeCommands)).toBe(commands);
   expect(await readLinkTarget(factoryCommands)).toBe(commands);
   expect(await readLinkTarget(codexPrompts)).toBe(commands);
   expect(await readLinkTarget(cursorCommands)).toBe(commands);
   expect(await readLinkTarget(opencodeCommands)).toBe(commands);
+  expect(await readLinkTarget(geminiCommands)).toBe(commands);
   expect(await readLinkTarget(claudeAgents)).toBe(agentsFile);
   expect(await readLinkTarget(factoryAgents)).toBe(agentsFile);
   expect(await readLinkTarget(codexAgents)).toBe(agentsFile);
   expect(await readLinkTarget(opencodeAgents)).toBe(agentsFile);
   expect(await readLinkTarget(cursorSkills)).toBe(path.join(canonical, 'skills'));
   expect(await readLinkTarget(opencodeSkills)).toBe(path.join(canonical, 'skills'));
+  expect(await readLinkTarget(geminiSkills)).toBe(path.join(canonical, 'skills'));
 });
 
 test('adds cursor links when .cursor exists without .claude', async () => {
@@ -91,6 +95,7 @@ test('relinks Claude prompt when CLAUDE.md is added', async () => {
   expect(await readLinkTarget(codexAgents)).toBe(agentsFile);
 
   await writeFile(claudeFile, '# Claude override');
+  await writeFile(path.join(canonical, 'GEMINI.md'), '# Gemini override');
 
   const second = await buildLinkPlan({ scope: 'global', homeDir: home });
   const backupSecond = await createBackupSession({ canonicalRoot: path.join(home, '.agents'), scope: 'global', operation: 'test' });
@@ -99,6 +104,7 @@ test('relinks Claude prompt when CLAUDE.md is added', async () => {
   expect(result.applied).toBeGreaterThan(0);
 
   expect(await readLinkTarget(claudeAgents)).toBe(claudeFile);
+  expect(await readLinkTarget(path.join(home, '.gemini', 'GEMINI.md'))).toBe(path.join(canonical, 'GEMINI.md'));
   expect(await readLinkTarget(factoryAgents)).toBe(agentsFile);
   expect(await readLinkTarget(codexAgents)).toBe(agentsFile);
 });

--- a/tests/migrate.test.ts
+++ b/tests/migrate.test.ts
@@ -17,14 +17,17 @@ test('migration wizard copies selected items, backs up, and links', async () => 
   await writeFile(path.join(home, '.claude', 'commands', 'log-session.md'), 'claude');
   await writeFile(path.join(home, '.factory', 'commands', 'log-session.md'), 'factory');
   await writeFile(path.join(home, '.codex', 'prompts', 'unique.md'), 'codex');
+  await writeFile(path.join(home, '.gemini', 'commands', 'log-session.toml'), 'prompt = "gemini"');
 
   await writeFile(path.join(home, '.claude', 'hooks', 'hook.sh'), 'echo claude');
   await writeFile(path.join(home, '.factory', 'hooks', 'hook.sh'), 'echo factory');
 
   await createSkill(path.join(home, '.claude', 'skills'), 'alpha-skill');
   await createSkill(path.join(home, '.factory', 'skills'), 'alpha-skill');
+  await createSkill(path.join(home, '.gemini', 'skills'), 'alpha-skill');
 
   await writeFile(path.join(home, '.claude', 'CLAUDE.md'), '# CLAUDE');
+  await writeFile(path.join(home, '.gemini', 'GEMINI.md'), '# GEMINI AGENTS');
 
   const plan = await scanMigration({ scope: 'global', homeDir: home });
   expect(plan.conflicts.length).toBeGreaterThan(0);
@@ -43,10 +46,12 @@ test('migration wizard copies selected items, backs up, and links', async () => 
   const agentsRoot = path.join(home, '.agents');
   expect(fs.existsSync(path.join(agentsRoot, 'commands', 'log-session.md'))).toBe(true);
   expect(fs.existsSync(path.join(agentsRoot, 'commands', 'unique.md'))).toBe(true);
+  expect(fs.existsSync(path.join(agentsRoot, 'commands', 'log-session.toml'))).toBe(true);
   expect(fs.existsSync(path.join(agentsRoot, 'hooks', 'hook.sh'))).toBe(true);
   expect(fs.existsSync(path.join(agentsRoot, 'skills', 'alpha-skill', 'SKILL.md'))).toBe(true);
   expect(fs.existsSync(path.join(agentsRoot, 'AGENTS.md'))).toBe(true);
   expect(fs.existsSync(path.join(agentsRoot, 'CLAUDE.md'))).toBe(true);
+  expect(fs.existsSync(path.join(agentsRoot, 'GEMINI.md'))).toBe(true);
 
   // Backup created
   expect(fs.existsSync(result.backupDir)).toBe(true);
@@ -55,4 +60,5 @@ test('migration wizard copies selected items, backs up, and links', async () => 
   expect(await readLinkTarget(path.join(home, '.claude', 'commands'))).toBe(path.join(agentsRoot, 'commands'));
   expect(await readLinkTarget(path.join(home, '.factory', 'commands'))).toBe(path.join(agentsRoot, 'commands'));
   expect(await readLinkTarget(path.join(home, '.codex', 'prompts'))).toBe(path.join(agentsRoot, 'commands'));
+  expect(await readLinkTarget(path.join(home, '.gemini', 'commands'))).toBe(path.join(agentsRoot, 'commands'));
 });


### PR DESCRIPTION
Add support for [Gemini CLI](https://github.com/google-gemini/gemini-cl) to dotagents 🚀 

Thanks for this awesome project @iannuttall, just wanted to stop by and add support for Gemini CLI as a client.

Quick summary of what I changed:
   - Added `gemini` as a supported client.
   - Paths: Defined `~/.gemini` (global) and `.gemini` (project) as target roots.
   - Mappings:
     - `.agents/commands` → `~/.gemini/commands`
     - `.agents/skills` → `~/.gemini/skills`
     - `.agents/GEMINI.md` → `~/.gemini/GEMINI.md` (with fallback to `AGENTS.md`).
   - Migration: Added support for migrating existing .gemini commands, skills, and context files into .agents.
   - CLI: Added Gemini to the client selection and status summary.
   - Documentation: Updated README.md with Gemini CLI details 
   - Tests: Verified all changes with updated test suites in `tests/linking.test.ts` and `tests/migrate.test.ts`.

If I missed anything just let me know and will happily correct. 

Thanks again for this great resource.