### PR TITLE
feat(skills): add GitHub Copilot skills support

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -136,6 +136,7 @@ async function selectClients(): Promise<Client[]> {
     { label: 'Cursor', value: 'cursor' },
     { label: 'OpenCode', value: 'opencode' },
     { label: 'Gemini', value: 'gemini' },
+    { label: 'GitHub', value: 'github' },
   ] as const;
   const selected = await multiselect({
     message: 'Select clients to manage',
@@ -155,6 +156,7 @@ function formatClients(clients: Client[]): string {
     cursor: 'Cursor',
     opencode: 'OpenCode',
     gemini: 'Gemini',
+    github: 'GitHub',
   };
   return clients.map((c) => names[c]).join(', ');
 }

--- a/src/core/mappings.ts
+++ b/src/core/mappings.ts
@@ -18,7 +18,7 @@ export async function getMappings(opts: MappingOptions): Promise<Mapping[]> {
   const agentsFallback = path.join(canonical, 'AGENTS.md');
   const claudeSource = await pathExists(claudeOverride) ? claudeOverride : agentsFallback;
   const geminiSource = await pathExists(geminiOverride) ? geminiOverride : agentsFallback;
-  const clients = new Set<Client>(opts.clients ?? ['claude', 'factory', 'codex', 'cursor', 'opencode', 'gemini']);
+  const clients = new Set<Client>(opts.clients ?? ['claude', 'factory', 'codex', 'cursor', 'opencode', 'gemini', 'github']);
   const opencodeSkillsRoot = opts.scope === 'global' ? roots.opencodeConfigRoot : roots.opencodeRoot;
 
   const mappings: Mapping[] = [];
@@ -91,6 +91,11 @@ export async function getMappings(opts: MappingOptions): Promise<Mapping[]> {
         clients.has('opencode') ? path.join(opencodeSkillsRoot, 'skills') : null,
         clients.has('cursor') ? path.join(roots.cursorRoot, 'skills') : null,
         clients.has('gemini') ? path.join(roots.geminiRoot, 'skills') : null,
+        clients.has('gemini') ? path.join(roots.geminiRoot, 'skills') : null,
+        // GitHub uses .github/skills for project scope and ~/.copilot/skills for global scope.
+        clients.has('github')
+          ? (opts.scope === 'global' ? path.join(roots.copilotRoot, 'skills') : path.join(roots.githubRoot, 'skills'))
+          : null,
       ].filter(Boolean) as string[],
       kind: 'dir',
     },

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -60,7 +60,7 @@ export async function scanMigration(opts: RootOptions & { clients?: Client[] }):
   const roots = resolveRoots(opts);
   const canonicalRoot = roots.canonicalRoot;
   const candidatesByTarget = new Map<string, MigrationCandidate[]>();
-  const clients = new Set<Client>(opts.clients ?? ['claude', 'factory', 'codex', 'cursor', 'opencode', 'gemini']);
+  const clients = new Set<Client>(opts.clients ?? ['claude', 'factory', 'codex', 'cursor', 'opencode', 'gemini', 'github']);
   const includeAgentFiles = opts.scope === 'global';
 
   const canonicalCommands = path.join(canonicalRoot, 'commands');
@@ -90,6 +90,12 @@ export async function scanMigration(opts: RootOptions & { clients?: Client[] }):
       clients.has('cursor') ? { label: 'Cursor skills', dir: path.join(roots.cursorRoot, 'skills') } : null,
       clients.has('opencode') ? { label: 'OpenCode skills', dir: path.join(opencodeSkillsRoot, 'skills') } : null,
       clients.has('gemini') ? { label: 'Gemini skills', dir: path.join(roots.geminiRoot, 'skills') } : null,
+      // GitHub uses .github/skills for project scope and ~/.copilot/skills for global scope.
+      clients.has('github')
+        ? (opts.scope === 'global'
+          ? { label: 'GitHub Copilot skills', dir: path.join(roots.copilotRoot, 'skills') }
+          : { label: 'GitHub skills', dir: path.join(roots.githubRoot, 'skills') })
+        : null,
     ].filter(Boolean) as { label: string; dir: string }[],
     agents: includeAgentFiles
       ? [

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -17,6 +17,8 @@ export type ResolvedRoots = {
   opencodeRoot: string;
   opencodeConfigRoot: string;
   geminiRoot: string;
+  githubRoot: string;
+  copilotRoot: string;
   projectRoot: string;
   homeDir: string;
 };
@@ -34,6 +36,8 @@ export function resolveRoots(opts: RootOptions): ResolvedRoots {
       opencodeRoot: path.join(homeDir, '.config', 'opencode'),
       opencodeConfigRoot: path.join(homeDir, '.config', 'opencode'),
       geminiRoot: path.join(homeDir, '.gemini'),
+      githubRoot: path.join(projectRoot, '.github'),
+      copilotRoot: path.join(homeDir, '.copilot'),
       projectRoot,
       homeDir,
     };
@@ -47,6 +51,8 @@ export function resolveRoots(opts: RootOptions): ResolvedRoots {
     opencodeRoot: path.join(projectRoot, '.opencode'),
     opencodeConfigRoot: path.join(homeDir, '.config', 'opencode'),
     geminiRoot: path.join(projectRoot, '.gemini'),
+    githubRoot: path.join(projectRoot, '.github'),
+    copilotRoot: path.join(homeDir, '.copilot'),
     projectRoot,
     homeDir,
   };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,6 +1,6 @@
 export type Scope = 'global' | 'project';
 export type SourceKind = 'file' | 'dir';
-export type Client = 'claude' | 'factory' | 'codex' | 'cursor' | 'opencode' | 'gemini';
+export type Client = 'claude' | 'factory' | 'codex' | 'cursor' | 'opencode' | 'gemini' | 'github';
 
 export type Mapping = {
   name: string;


### PR DESCRIPTION
## Summary

Adds support for GitHub Copilot's Agent Skills as a new client in dotagents.

- **Project scope**: Links `.agents/skills` → `.github/skills`
- **Global scope**: Links `.agents/skills` → `~/.copilot/skills`
- Includes migration support to import existing GitHub Copilot skills

## Changes

- Add `'github'` to the `Client` type
- Add `githubRoot` and `copilotRoot` path resolution
- Update mappings and migration to support GitHub's skill locations
- Add GitHub to the CLI client selection menu
- Add tests for linking and migration

## References

Based on the [GitHub Agent Skills specification](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills).