### PR TITLE
feat(cli): add Ampcode client support

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -137,6 +137,7 @@ async function selectClients(): Promise<Client[]> {
     { label: 'OpenCode', value: 'opencode' },
     { label: 'Gemini', value: 'gemini' },
     { label: 'GitHub', value: 'github' },
+    { label: 'Ampcode', value: 'ampcode' },
   ] as const;
   const selected = await multiselect({
     message: 'Select clients to manage',
@@ -157,6 +158,7 @@ function formatClients(clients: Client[]): string {
     opencode: 'OpenCode',
     gemini: 'Gemini',
     github: 'GitHub',
+    ampcode: 'Ampcode',
   };
   return clients.map((c) => names[c]).join(', ');
 }
@@ -280,7 +282,12 @@ async function run(): Promise<void> {
     ].join('\n'), 'Overview');
 
     const options: { label: string; value: Action }[] = [];
-    if (changes > 0) options.push({ label: `Apply ${changes} changes to .agents`, value: 'change' });
+    if (changes > 0 || conflicts > 0) {
+      const label = conflicts > 0 && changes === 0
+        ? `Resolve ${conflicts} ${pluralize(conflicts, 'conflict')}`
+        : `Apply ${changes} ${pluralize(changes, 'change')}`;
+      options.push({ label, value: 'change' });
+    }
     options.push({ label: 'View status', value: 'status' });
     options.push({ label: 'Change clients', value: 'clients' });
     options.push({ label: 'Undo last change', value: 'undo' });

--- a/src/core/mappings.ts
+++ b/src/core/mappings.ts
@@ -18,7 +18,7 @@ export async function getMappings(opts: MappingOptions): Promise<Mapping[]> {
   const agentsFallback = path.join(canonical, 'AGENTS.md');
   const claudeSource = await pathExists(claudeOverride) ? claudeOverride : agentsFallback;
   const geminiSource = await pathExists(geminiOverride) ? geminiOverride : agentsFallback;
-  const clients = new Set<Client>(opts.clients ?? ['claude', 'factory', 'codex', 'cursor', 'opencode', 'gemini', 'github']);
+  const clients = new Set<Client>(opts.clients ?? ['claude', 'factory', 'codex', 'cursor', 'opencode', 'gemini', 'github', 'ampcode']);
   const opencodeSkillsRoot = opts.scope === 'global' ? roots.opencodeConfigRoot : roots.opencodeRoot;
 
   const mappings: Mapping[] = [];
@@ -46,6 +46,7 @@ export async function getMappings(opts: MappingOptions): Promise<Mapping[]> {
       clients.has('factory') ? path.join(roots.factoryRoot, 'AGENTS.md') : null,
       clients.has('codex') ? path.join(roots.codexRoot, 'AGENTS.md') : null,
       clients.has('opencode') ? path.join(roots.opencodeConfigRoot, 'AGENTS.md') : null,
+      clients.has('ampcode') ? path.join(roots.ampcodeConfigRoot, 'AGENTS.md') : null,
     ].filter(Boolean) as string[];
 
     if (agentTargets.length > 0) {
@@ -90,7 +91,6 @@ export async function getMappings(opts: MappingOptions): Promise<Mapping[]> {
         clients.has('codex') ? path.join(roots.codexRoot, 'skills') : null,
         clients.has('opencode') ? path.join(opencodeSkillsRoot, 'skills') : null,
         clients.has('cursor') ? path.join(roots.cursorRoot, 'skills') : null,
-        clients.has('gemini') ? path.join(roots.geminiRoot, 'skills') : null,
         clients.has('gemini') ? path.join(roots.geminiRoot, 'skills') : null,
         // GitHub uses .github/skills for project scope and ~/.copilot/skills for global scope.
         clients.has('github')

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -60,7 +60,7 @@ export async function scanMigration(opts: RootOptions & { clients?: Client[] }):
   const roots = resolveRoots(opts);
   const canonicalRoot = roots.canonicalRoot;
   const candidatesByTarget = new Map<string, MigrationCandidate[]>();
-  const clients = new Set<Client>(opts.clients ?? ['claude', 'factory', 'codex', 'cursor', 'opencode', 'gemini', 'github']);
+  const clients = new Set<Client>(opts.clients ?? ['claude', 'factory', 'codex', 'cursor', 'opencode', 'gemini', 'github', 'ampcode']);
   const includeAgentFiles = opts.scope === 'global';
 
   const canonicalCommands = path.join(canonicalRoot, 'commands');
@@ -103,6 +103,7 @@ export async function scanMigration(opts: RootOptions & { clients?: Client[] }):
           clients.has('factory') ? { label: 'Factory AGENTS.md', file: path.join(roots.factoryRoot, 'AGENTS.md') } : null,
           clients.has('codex') ? { label: 'Codex AGENTS.md', file: path.join(roots.codexRoot, 'AGENTS.md') } : null,
           clients.has('opencode') ? { label: 'OpenCode AGENTS.md', file: path.join(roots.opencodeConfigRoot, 'AGENTS.md') } : null,
+          clients.has('ampcode') ? { label: 'Ampcode AGENTS.md', file: path.join(roots.ampcodeConfigRoot, 'AGENTS.md') } : null,
         ].filter(Boolean) as { label: string; file: string }[]
       : [],
     claude: includeAgentFiles

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -19,6 +19,7 @@ export type ResolvedRoots = {
   geminiRoot: string;
   githubRoot: string;
   copilotRoot: string;
+  ampcodeConfigRoot: string;
   projectRoot: string;
   homeDir: string;
 };
@@ -38,6 +39,7 @@ export function resolveRoots(opts: RootOptions): ResolvedRoots {
       geminiRoot: path.join(homeDir, '.gemini'),
       githubRoot: path.join(projectRoot, '.github'),
       copilotRoot: path.join(homeDir, '.copilot'),
+      ampcodeConfigRoot: path.join(homeDir, '.config', 'amp'),
       projectRoot,
       homeDir,
     };
@@ -53,6 +55,7 @@ export function resolveRoots(opts: RootOptions): ResolvedRoots {
     geminiRoot: path.join(projectRoot, '.gemini'),
     githubRoot: path.join(projectRoot, '.github'),
     copilotRoot: path.join(homeDir, '.copilot'),
+    ampcodeConfigRoot: path.join(homeDir, '.config', 'amp'),
     projectRoot,
     homeDir,
   };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,6 +1,6 @@
 export type Scope = 'global' | 'project';
 export type SourceKind = 'file' | 'dir';
-export type Client = 'claude' | 'factory' | 'codex' | 'cursor' | 'opencode' | 'gemini' | 'github';
+export type Client = 'claude' | 'factory' | 'codex' | 'cursor' | 'opencode' | 'gemini' | 'github' | 'ampcode';
 
 export type Mapping = {
   name: string;


### PR DESCRIPTION
## Summary
Adds Sourcegraph's Amp CLI as a supported client.

Amp natively reads from `.agents/` for workspace commands and skills, so no symlinks are needed there. The only thing we add is the global AGENTS.md symlink to `~/.config/amp/AGENTS.md`.

**Changes:**
- Added `ampcode` to Client type
- Added `ampcodeConfigRoot` path (`~/.config/amp/`)
- Added ampcode to agents-md mapping (global only)
- Added ampcode to migration sources for AGENTS.md
- Added Ampcode to CLI client selection

**Bonus fix:** The "Apply changes" option was hidden when only conflicts existed (0 changes, 1+ conflicts). Now shows "Resolve X conflicts" in that case.

## Test plan
- [x] Build passes
- [x] Select Ampcode in CLI → only AGENTS.md shows as target
- [x] Conflict resolution works when existing file at `~/.config/amp/AGENTS.md`