### PR TITLE
fix: use relative paths for symlinks to improve portability

### DIFF
--- a/src/core/link-target.ts
+++ b/src/core/link-target.ts
@@ -1,0 +1,26 @@
+import path from 'path';
+import type { SourceKind } from './types.js';
+
+export type LinkTarget = {
+  link: string;
+  isRelative: boolean;
+};
+
+export function getLinkTarget(source: string, target: string, kind: SourceKind): LinkTarget {
+  const resolvedSource = path.resolve(source);
+  if (process.platform === 'win32' && kind === 'dir') {
+    return { link: resolvedSource, isRelative: false };
+  }
+
+  const relative = path.relative(path.dirname(target), resolvedSource);
+  if (!relative || path.isAbsolute(relative)) {
+    return { link: resolvedSource, isRelative: false };
+  }
+
+  const resolvedRelative = path.resolve(path.dirname(target), relative);
+  if (resolvedRelative !== resolvedSource) {
+    return { link: resolvedSource, isRelative: false };
+  }
+
+  return { link: relative, isRelative: true };
+}


### PR DESCRIPTION
## Summary

This PR fixes the symlink portability issue by using relative paths instead of absolute paths when creating symlinks.

### Problem

Previously, symlinks were created with absolute paths (e.g., `/home/user/project/.agents/commands`). This caused project-level symlinks to break when:
- The project directory was moved or renamed
- The project was cloned to a different location
- The project was shared with other developers

### Solution

- Symlinks now use relative paths (e.g., `../.agents/commands`)
- Existing absolute symlinks are automatically detected and migrated to relative paths on the next run
- All existing tests continue to pass, with 5 new tests added for the new behavior

### Changes

- **`src/core/apply.ts`**: Modified `createLink()` to compute and use relative paths via `path.relative()`
- **`src/core/plan.ts`**: Added detection logic in `analyzeTarget()` to identify absolute symlinks that need migration
- **`tests/linking.test.ts`**: Added 5 new tests:
  - `creates symlinks with relative paths`
  - `creates relative symlinks for nested targets`
  - `migrates absolute symlinks to relative`
  - `project symlinks are portable after directory move`

### Testing

All 12 tests pass:
```
bun test v1.3.6
 12 pass
 0 fail
 86 expect() calls
Ran 12 tests across 3 files. [159.00ms]
```

### Notes

- On Windows, directory junctions typically require absolute paths. This change may affect Windows users using junction-type symlinks. A future enhancement could detect the platform and use absolute paths only for Windows junctions if needed.