### PR TITLE
fix(opencode): use config root for globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Global home affects all projects. Project folder only affects the current direct
 
 `.agents/AGENTS.md` → `~/.config/opencode/AGENTS.md`
 
-`.agents/commands` → `~/.opencode/commands`
+`.agents/commands` → `~/.config/opencode/commands`
 
 `.agents/skills` → `~/.claude/skills`
 
@@ -67,7 +67,7 @@ Global home affects all projects. Project folder only affects the current direct
 
 `.agents/skills` → `~/.cursor/skills`
 
-`.agents/skills` → `~/.opencode/skills`
+`.agents/skills` → `~/.config/opencode/skills`
 
 Project scope links only commands/hooks/skills into the project’s client folders (no AGENTS/CLAUDE rules).
 

--- a/src/core/mappings.ts
+++ b/src/core/mappings.ts
@@ -17,6 +17,7 @@ export async function getMappings(opts: MappingOptions): Promise<Mapping[]> {
   const agentsFallback = path.join(canonical, 'AGENTS.md');
   const agentsSource = await pathExists(claudeOverride) ? claudeOverride : agentsFallback;
   const clients = new Set<Client>(opts.clients ?? ['claude', 'factory', 'codex', 'cursor', 'opencode']);
+  const opencodeSkillsRoot = opts.scope === 'global' ? roots.opencodeConfigRoot : roots.opencodeRoot;
 
   const mappings: Mapping[] = [];
   const includeAgentFiles = opts.scope === 'global';
@@ -75,7 +76,7 @@ export async function getMappings(opts: MappingOptions): Promise<Mapping[]> {
         clients.has('claude') ? path.join(roots.claudeRoot, 'skills') : null,
         clients.has('factory') ? path.join(roots.factoryRoot, 'skills') : null,
         clients.has('codex') ? path.join(roots.codexRoot, 'skills') : null,
-        clients.has('opencode') ? path.join(roots.opencodeRoot, 'skills') : null,
+        clients.has('opencode') ? path.join(opencodeSkillsRoot, 'skills') : null,
         clients.has('cursor') ? path.join(roots.cursorRoot, 'skills') : null,
       ].filter(Boolean) as string[],
       kind: 'dir',

--- a/src/core/migrate.ts
+++ b/src/core/migrate.ts
@@ -68,6 +68,7 @@ export async function scanMigration(opts: RootOptions & { clients?: Client[] }):
   const canonicalSkills = path.join(canonicalRoot, 'skills');
   const canonicalAgents = path.join(canonicalRoot, 'AGENTS.md');
   const canonicalClaude = path.join(canonicalRoot, 'CLAUDE.md');
+  const opencodeSkillsRoot = opts.scope === 'global' ? roots.opencodeConfigRoot : roots.opencodeRoot;
 
   const sources = {
     commands: [
@@ -86,7 +87,7 @@ export async function scanMigration(opts: RootOptions & { clients?: Client[] }):
       clients.has('factory') ? { label: 'Factory skills', dir: path.join(roots.factoryRoot, 'skills') } : null,
       clients.has('codex') ? { label: 'Codex skills', dir: path.join(roots.codexRoot, 'skills') } : null,
       clients.has('cursor') ? { label: 'Cursor skills', dir: path.join(roots.cursorRoot, 'skills') } : null,
-      clients.has('opencode') ? { label: 'OpenCode skills', dir: path.join(roots.opencodeRoot, 'skills') } : null,
+      clients.has('opencode') ? { label: 'OpenCode skills', dir: path.join(opencodeSkillsRoot, 'skills') } : null,
     ].filter(Boolean) as { label: string; dir: string }[],
     agents: includeAgentFiles
       ? [

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -30,7 +30,7 @@ export function resolveRoots(opts: RootOptions): ResolvedRoots {
       factoryRoot: path.join(homeDir, '.factory'),
       codexRoot: path.join(homeDir, '.codex'),
       cursorRoot: path.join(homeDir, '.cursor'),
-      opencodeRoot: path.join(homeDir, '.opencode'),
+      opencodeRoot: path.join(homeDir, '.config', 'opencode'),
       opencodeConfigRoot: path.join(homeDir, '.config', 'opencode'),
       projectRoot,
       homeDir,

--- a/tests/linking.test.ts
+++ b/tests/linking.test.ts
@@ -30,13 +30,13 @@ test('creates symlinks from canonical .agents to tool homes', async () => {
   const factoryCommands = path.join(home, '.factory', 'commands');
   const codexPrompts = path.join(home, '.codex', 'prompts');
   const cursorCommands = path.join(home, '.cursor', 'commands');
-  const opencodeCommands = path.join(home, '.opencode', 'commands');
+  const opencodeCommands = path.join(home, '.config', 'opencode', 'commands');
   const claudeAgents = path.join(home, '.claude', 'CLAUDE.md');
   const factoryAgents = path.join(home, '.factory', 'AGENTS.md');
   const codexAgents = path.join(home, '.codex', 'AGENTS.md');
   const opencodeAgents = path.join(home, '.config', 'opencode', 'AGENTS.md');
   const cursorSkills = path.join(home, '.cursor', 'skills');
-  const opencodeSkills = path.join(home, '.opencode', 'skills');
+  const opencodeSkills = path.join(home, '.config', 'opencode', 'skills');
 
   expect(await readLinkTarget(claudeCommands)).toBe(commands);
   expect(await readLinkTarget(factoryCommands)).toBe(commands);


### PR DESCRIPTION
## Summary
- point global OpenCode commands/skills at ~/.config/opencode
- keep per-project paths under .opencode
- update docs and tests

## Testing
- bun test tests/linking.test.ts

Fixes #5