### PR TITLE
feat: add Roo Code support

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -136,6 +136,7 @@ async function selectClients(): Promise<Client[]> {
     { label: 'Cursor', value: 'cursor' },
     { label: 'OpenCode', value: 'opencode' },
     { label: 'Gemini', value: 'gemini' },
+    { label: 'Roo Code', value: 'roocode' },
     { label: 'GitHub', value: 'github' },
     { label: 'Ampcode', value: 'ampcode' },
   ] as const;
@@ -157,6 +158,7 @@ function formatClients(clients: Client[]): string {
     cursor: 'Cursor',
     opencode: 'OpenCode',
     gemini: 'Gemini',
+    roocode: 'Roo Code',
     github: 'GitHub',
     ampcode: 'Ampcode',
   };

--- a/src/core/mappings.ts
+++ b/src/core/mappings.ts
@@ -18,7 +18,7 @@ export async function getMappings(opts: MappingOptions): Promise<Mapping[]> {
   const agentsFallback = path.join(canonical, 'AGENTS.md');
   const claudeSource = await pathExists(claudeOverride) ? claudeOverride : agentsFallback;
   const geminiSource = await pathExists(geminiOverride) ? geminiOverride : agentsFallback;
-  const clients = new Set<Client>(opts.clients ?? ['claude', 'factory', 'codex', 'cursor', 'opencode', 'gemini', 'github', 'ampcode']);
+  const clients = new Set<Client>(opts.clients ?? ['claude', 'factory', 'codex', 'cursor', 'opencode', 'gemini', 'github', 'ampcode', 'roocode']);
   const opencodeSkillsRoot = opts.scope === 'global' ? roots.opencodeConfigRoot : roots.opencodeRoot;
 
   const mappings: Mapping[] = [];
@@ -47,6 +47,7 @@ export async function getMappings(opts: MappingOptions): Promise<Mapping[]> {
       clients.has('codex') ? path.join(roots.codexRoot, 'AGENTS.md') : null,
       clients.has('opencode') ? path.join(roots.opencodeConfigRoot, 'AGENTS.md') : null,
       clients.has('ampcode') ? path.join(roots.ampcodeConfigRoot, 'AGENTS.md') : null,
+      clients.has('roocode') ? path.join(roots.roocodeRoot, 'AGENTS.md') : null,
     ].filter(Boolean) as string[];
 
     if (agentTargets.length > 0) {
@@ -70,6 +71,7 @@ export async function getMappings(opts: MappingOptions): Promise<Mapping[]> {
         clients.has('opencode') ? path.join(roots.opencodeRoot, 'commands') : null,
         clients.has('cursor') ? path.join(roots.cursorRoot, 'commands') : null,
         clients.has('gemini') ? path.join(roots.geminiRoot, 'commands') : null,
+        clients.has('roocode') ? path.join(roots.roocodeRoot, 'commands') : null,
       ].filter(Boolean) as string[],
       kind: 'dir',
     },
@@ -96,6 +98,15 @@ export async function getMappings(opts: MappingOptions): Promise<Mapping[]> {
         clients.has('github')
           ? (opts.scope === 'global' ? path.join(roots.copilotRoot, 'skills') : path.join(roots.githubRoot, 'skills'))
           : null,
+        clients.has('roocode') ? path.join(roots.roocodeRoot, 'skills') : null,
+      ].filter(Boolean) as string[],
+      kind: 'dir',
+    },
+    {
+      name: 'rules',
+      source: path.join(canonical, 'rules'),
+      targets: [
+        clients.has('roocode') ? path.join(roots.roocodeRoot, 'rules') : null,
       ].filter(Boolean) as string[],
       kind: 'dir',
     },

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -20,6 +20,7 @@ export type ResolvedRoots = {
   githubRoot: string;
   copilotRoot: string;
   ampcodeConfigRoot: string;
+  roocodeRoot: string;
   projectRoot: string;
   homeDir: string;
 };
@@ -40,6 +41,7 @@ export function resolveRoots(opts: RootOptions): ResolvedRoots {
       githubRoot: path.join(projectRoot, '.github'),
       copilotRoot: path.join(homeDir, '.copilot'),
       ampcodeConfigRoot: path.join(homeDir, '.config', 'amp'),
+      roocodeRoot: path.join(homeDir, '.roo'),
       projectRoot,
       homeDir,
     };
@@ -56,6 +58,7 @@ export function resolveRoots(opts: RootOptions): ResolvedRoots {
     githubRoot: path.join(projectRoot, '.github'),
     copilotRoot: path.join(homeDir, '.copilot'),
     ampcodeConfigRoot: path.join(homeDir, '.config', 'amp'),
+    roocodeRoot: path.join(projectRoot, '.roo'),
     projectRoot,
     homeDir,
   };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,6 +1,6 @@
 export type Scope = 'global' | 'project';
 export type SourceKind = 'file' | 'dir';
-export type Client = 'claude' | 'factory' | 'codex' | 'cursor' | 'opencode' | 'gemini' | 'github' | 'ampcode';
+export type Client = 'claude' | 'factory' | 'codex' | 'cursor' | 'opencode' | 'gemini' | 'github' | 'ampcode' | 'roocode';
 
 export type Mapping = {
   name: string;

--- a/tests/linking.test.ts
+++ b/tests/linking.test.ts
@@ -200,6 +200,56 @@ test('github skills link to ~/.copilot/skills in global scope', async () => {
   expect(await readLinkTarget(copilotSkills)).toBe(skills);
 });
 
+test('roocode links to .roo directory in global scope', async () => {
+  const home = await makeTempDir('dotagents-home-');
+
+  const plan = await buildLinkPlan({ scope: 'global', homeDir: home, clients: ['roocode'] });
+  const backup = await createBackupSession({ canonicalRoot: path.join(home, '.agents'), scope: 'global', operation: 'test' });
+  const result = await applyLinkPlan(plan, { backup });
+  await finalizeBackup(backup);
+  expect(result.applied).toBeGreaterThan(0);
+
+  const canonical = path.join(home, '.agents');
+  const commands = path.join(canonical, 'commands');
+  const skills = path.join(canonical, 'skills');
+  const rules = path.join(canonical, 'rules');
+  const agentsFile = path.join(canonical, 'AGENTS.md');
+
+  const roocodeCommands = path.join(home, '.roo', 'commands');
+  const roocodeSkills = path.join(home, '.roo', 'skills');
+  const roocodeRules = path.join(home, '.roo', 'rules');
+  const roocodeAgents = path.join(home, '.roo', 'AGENTS.md');
+
+  expect(await readLinkTarget(roocodeCommands)).toBe(commands);
+  expect(await readLinkTarget(roocodeSkills)).toBe(skills);
+  expect(await readLinkTarget(roocodeRules)).toBe(rules);
+  expect(await readLinkTarget(roocodeAgents)).toBe(agentsFile);
+});
+
+test('roocode links to .roo directory in project scope', async () => {
+  const home = await makeTempDir('dotagents-home-');
+  const project = await makeTempDir('dotagents-project-');
+
+  const plan = await buildLinkPlan({ scope: 'project', homeDir: home, projectRoot: project, clients: ['roocode'] });
+  const backup = await createBackupSession({ canonicalRoot: path.join(project, '.agents'), scope: 'project', operation: 'test' });
+  const result = await applyLinkPlan(plan, { backup });
+  await finalizeBackup(backup);
+  expect(result.applied).toBeGreaterThan(0);
+
+  const canonical = path.join(project, '.agents');
+  const commands = path.join(canonical, 'commands');
+  const skills = path.join(canonical, 'skills');
+  const rules = path.join(canonical, 'rules');
+
+  const roocodeCommands = path.join(project, '.roo', 'commands');
+  const roocodeSkills = path.join(project, '.roo', 'skills');
+  const roocodeRules = path.join(project, '.roo', 'rules');
+
+  expect(await readLinkTarget(roocodeCommands)).toBe(commands);
+  expect(await readLinkTarget(roocodeSkills)).toBe(skills);
+  expect(await readLinkTarget(roocodeRules)).toBe(rules);
+});
+
 test('creates symlinks with relative paths when supported', async () => {
   const home = await makeTempDir('dotagents-home-');
 


### PR DESCRIPTION
## Summary
Adds support for Roo Code configuration directory to dotagents.

## Changes
- Added 'roocode' to Client union type in types.ts
- Added roocodeRoot function to paths.ts for Roo Code's .roo configuration directory
- Added Roo Code mappings for:
  - AGENTS.md → ~/.roo/AGENTS.md (global) or .roo/AGENTS.md (project)
  - commands → ~/.roo/commands or .roo/commands
  - skills → ~/.roo/skills or .roo/skills  
  - rules → ~/.roo/rules or .roo/rules
- Added Roo Code to client selection in CLI
- Added tests for roocode mappings

## Test plan
- All 17 tests pass including new roocode tests
- Verified mappings are correctly generated for both global and project scopes